### PR TITLE
feat: implement fast teardown

### DIFF
--- a/gasket/Cargo.toml
+++ b/gasket/Cargo.toml
@@ -24,6 +24,8 @@ tokio-util = "0.7.13"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.16"
+tokio = { version = "1", features = ["rt", "time", "sync", "macros", "rt-multi-thread"] }
+approx = "0.5.1"
 
 [features]
 derive = ["gasket-derive"]

--- a/gasket/Cargo.toml
+++ b/gasket/Cargo.toml
@@ -20,6 +20,7 @@ tokio = { version = "1", features = ["rt", "time", "sync", "macros"] }
 tracing = "0.1.37"
 gasket-derive = { version = "0.8.0", path = "../gasket-derive", optional = true }
 signal-hook = "0.3.17"
+tokio-util = "0.7.13"
 
 [dev-dependencies]
 tracing-subscriber = "0.3.16"

--- a/gasket/src/framework.rs
+++ b/gasket/src/framework.rs
@@ -95,18 +95,33 @@ where
     /// Bootstrap a new worker
     ///
     /// It's responsible for initializing any resources needed by the worker.
+    ///
+    /// This future will be cancelled if the stage is requested to shut-down.
+    /// The implementation of this function needs to be _cancellation
+    /// safe_. Don't rely on state that crosses await points to avoid potential
+    /// data loss.
     async fn bootstrap(stage: &S) -> Result<Self>;
 
     /// Schedule the next work unit for execution
     ///
     /// This usually means reading messages from input ports and returning a
     /// work unit that contains all data required for execution.
+    ///
+    /// This future will be cancelled if the stage is requested to shut-down.
+    /// The implementation of this function needs to be _cancellation safe_.
+    /// Don't rely on state that crosses await points to avoid potential data
+    /// loss.
     async fn schedule(&mut self, stage: &mut S) -> Result<WorkSchedule<S::Unit>>;
 
     /// Execute the action described by the work unit
     ///
     /// This usually means doing required computation, generating side-effect
     /// and submitting message through the output ports
+    ///
+    /// This future will be cancelled if the stage is requested to shut-down.
+    /// The implementation of this function needs to be _cancellation safe_.
+    /// Don't rely on state that crosses await points to avoid potential data
+    /// loss.
     async fn execute(&mut self, unit: &S::Unit, stage: &mut S) -> Result<()>;
 
     /// Shutdown the worker gracefully

--- a/gasket/src/retries.rs
+++ b/gasket/src/retries.rs
@@ -25,11 +25,7 @@ impl Retry {
         self.maxed(policy) && policy.dismissible
     }
 
-    pub async fn wait_backoff(
-        &self,
-        policy: &Policy,
-        mut cancel: tokio::sync::watch::Receiver<bool>,
-    ) {
+    pub async fn wait_backoff(&self, policy: &Policy, cancel: tokio_util::sync::CancellationToken) {
         let num = match &self.0 {
             Some(x) => x,
             None => return,
@@ -44,7 +40,7 @@ impl Retry {
         );
 
         tokio::select! {
-            _ = cancel.changed() => (),
+            _ = cancel.cancelled() => (),
             _ = tokio::time::sleep(backoff) => ()
         }
     }
@@ -62,6 +58,7 @@ pub struct Policy {
     pub max_backoff: Duration,
     pub dismissible: bool,
 }
+
 impl Policy {
     pub fn no_retry() -> Self {
         Self {


### PR DESCRIPTION
This PR improves significantly the time required for a graceful shutdown.

It works by wrapping each of the _actuate_ methods with an async cancel token. When the user triggers a shutdown, the state machine will cancel the ongoing async method and start switch into the teardown phase.

⚠️ DISCLAIMER, this change introduces a new requirement for stage implementors: the bootstrap, schedule, execute, etc functions need to be _cancellation safe_. If you've designed your stages to rely only "work units" for state, then you're good.