### PR TITLE
Fix gauges

### DIFF
--- a/gasket-prometheus/src/lib.rs
+++ b/gasket-prometheus/src/lib.rs
@@ -34,7 +34,7 @@ fn write_gauge(output: &mut impl Write, stage: &str, metric: &str, value: i64) {
 
     let mut pc = PrometheusMetric::build()
         .with_name(&name)
-        .with_metric_type(MetricType::Counter)
+        .with_metric_type(MetricType::Gauge)
         .with_help(&help)
         .build();
 


### PR DESCRIPTION
Fixing a small issue with gasket_prometheus. It seems like while copy-pasting, a Metric::Counter wasn't updated. It should be Metric::Gauge