### PR TITLE
feat: derive a StopReason from each stage's terminal cause

### DIFF
--- a/gasket/src/daemon.rs
+++ b/gasket/src/daemon.rs
@@ -79,7 +79,7 @@ impl Daemon {
     pub fn has_ended(&self) -> bool {
         self.0.iter().any(|tether| match tether.check_state() {
             TetherState::Alive(p) => {
-                matches!(p, StagePhase::Ended)
+                matches!(p, StagePhase::Ended(_))
             }
             _ => true,
         })
@@ -90,9 +90,8 @@ impl Daemon {
     /// A worker that finished its work means graceful finalization, which
     /// takes precedence over other stages erroring out as a cascading side
     /// effect (eg: a port closing because its counterpart stage already
-    /// ended). All terminal paths in the stage machine go through the `Ended`
-    /// phase, so the classification relies on each tether's `EndCause` rather
-    /// than on its phase.
+    /// ended). The terminal `Ended` phase carries the `EndCause` it ended
+    /// with, so the classification reads straight off each tether's phase.
     pub fn stop_reason(&self) -> Option<StopReason> {
         if self.is_terminated() {
             return Some(StopReason::Terminated);
@@ -103,33 +102,31 @@ impl Daemon {
         let mut dismissed = None;
 
         for tether in self.tethers() {
-            match tether.end_cause() {
-                Some(EndCause::Done) => return Some(StopReason::Finalized),
-                Some(EndCause::Errored) => {
-                    crashed.get_or_insert_with(|| StopReason::Crashed {
-                        stage: tether.name().to_owned(),
-                    });
+            let stage = || tether.name().to_owned();
+
+            match tether.check_state() {
+                // a stage that finalized gracefully wins outright
+                TetherState::Alive(StagePhase::Ended(EndCause::Done))
+                | TetherState::Finished(StagePhase::Ended(EndCause::Done)) => {
+                    return Some(StopReason::Finalized);
                 }
-                Some(EndCause::Dismissed) => {
-                    dismissed.get_or_insert_with(|| StopReason::Dismissed {
-                        stage: tether.name().to_owned(),
-                    });
+                TetherState::Alive(StagePhase::Ended(EndCause::Errored))
+                | TetherState::Finished(StagePhase::Ended(EndCause::Errored)) => {
+                    crashed.get_or_insert_with(|| StopReason::Crashed { stage: stage() });
                 }
-                None => match tether.check_state() {
-                    // the stage thread died without recording a cause, which
-                    // means it panicked mid-work
-                    TetherState::Dropped | TetherState::Finished(_) => {
-                        crashed.get_or_insert_with(|| StopReason::Crashed {
-                            stage: tether.name().to_owned(),
-                        });
-                    }
-                    TetherState::Blocked(_) => {
-                        blocked.get_or_insert_with(|| StopReason::Blocked {
-                            stage: tether.name().to_owned(),
-                        });
-                    }
-                    TetherState::Alive(_) => (),
-                },
+                TetherState::Alive(StagePhase::Ended(EndCause::Dismissed))
+                | TetherState::Finished(StagePhase::Ended(EndCause::Dismissed)) => {
+                    dismissed.get_or_insert_with(|| StopReason::Dismissed { stage: stage() });
+                }
+                // the thread is gone but never reached `Ended`, so it panicked
+                // mid-work
+                TetherState::Dropped | TetherState::Finished(_) => {
+                    crashed.get_or_insert_with(|| StopReason::Crashed { stage: stage() });
+                }
+                TetherState::Blocked(_) => {
+                    blocked.get_or_insert_with(|| StopReason::Blocked { stage: stage() });
+                }
+                TetherState::Alive(_) => (),
             }
         }
 

--- a/gasket/src/daemon.rs
+++ b/gasket/src/daemon.rs
@@ -1,4 +1,5 @@
 use std::{
+    fmt,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -8,7 +9,49 @@ use std::{
 
 use tracing::{debug, info, warn};
 
-use crate::runtime::{StagePhase, Tether, TetherState};
+use crate::runtime::{EndCause, StagePhase, Tether, TetherState};
+
+/// Why the daemon's stop condition triggered.
+///
+/// Computed from the state of the tethers *before* teardown, so a graceful
+/// finalization can be told apart from a crashed or stalled stage (eg: to
+/// decide the process exit code).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopReason {
+    /// the process received an OS termination signal
+    Terminated,
+    /// a stage finalized its work gracefully
+    Finalized,
+    /// a stage was dismissed from the outside
+    Dismissed { stage: String },
+    /// a stage ended (worker error or thread death) without finalizing
+    Crashed { stage: String },
+    /// a stage stopped responding (tick timeout exceeded)
+    Blocked { stage: String },
+}
+
+impl StopReason {
+    /// Whether the pipeline stopped by finalizing its work or by explicit
+    /// request, as opposed to crashing or stalling.
+    pub fn is_graceful(&self) -> bool {
+        matches!(
+            self,
+            StopReason::Terminated | StopReason::Finalized | StopReason::Dismissed { .. }
+        )
+    }
+}
+
+impl fmt::Display for StopReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            StopReason::Terminated => write!(f, "process received a termination signal"),
+            StopReason::Finalized => write!(f, "a stage finalized its work"),
+            StopReason::Dismissed { stage } => write!(f, "stage '{stage}' was dismissed"),
+            StopReason::Crashed { stage } => write!(f, "stage '{stage}' ended before finalizing"),
+            StopReason::Blocked { stage } => write!(f, "stage '{stage}' stopped responding"),
+        }
+    }
+}
 
 #[derive(Debug)]
 pub struct Daemon(Vec<Tether>, Arc<AtomicBool>);
@@ -42,18 +85,65 @@ impl Daemon {
         })
     }
 
-    pub fn should_stop(&self) -> bool {
+    /// Why the daemon should stop, if it should at all.
+    ///
+    /// A worker that finished its work means graceful finalization, which
+    /// takes precedence over other stages erroring out as a cascading side
+    /// effect (eg: a port closing because its counterpart stage already
+    /// ended). All terminal paths in the stage machine go through the `Ended`
+    /// phase, so the classification relies on each tether's `EndCause` rather
+    /// than on its phase.
+    pub fn stop_reason(&self) -> Option<StopReason> {
         if self.is_terminated() {
-            warn!("daemon terminated by user");
-            return true;
+            return Some(StopReason::Terminated);
         }
 
-        if self.has_ended() {
-            warn!("pipeline ended or stalled");
-            return true;
+        let mut crashed = None;
+        let mut blocked = None;
+        let mut dismissed = None;
+
+        for tether in self.tethers() {
+            match tether.end_cause() {
+                Some(EndCause::Done) => return Some(StopReason::Finalized),
+                Some(EndCause::Errored) => {
+                    crashed.get_or_insert_with(|| StopReason::Crashed {
+                        stage: tether.name().to_owned(),
+                    });
+                }
+                Some(EndCause::Dismissed) => {
+                    dismissed.get_or_insert_with(|| StopReason::Dismissed {
+                        stage: tether.name().to_owned(),
+                    });
+                }
+                None => match tether.check_state() {
+                    // the stage thread died without recording a cause, which
+                    // means it panicked mid-work
+                    TetherState::Dropped | TetherState::Finished(_) => {
+                        crashed.get_or_insert_with(|| StopReason::Crashed {
+                            stage: tether.name().to_owned(),
+                        });
+                    }
+                    TetherState::Blocked(_) => {
+                        blocked.get_or_insert_with(|| StopReason::Blocked {
+                            stage: tether.name().to_owned(),
+                        });
+                    }
+                    TetherState::Alive(_) => (),
+                },
+            }
         }
 
-        false
+        crashed.or(blocked).or(dismissed)
+    }
+
+    pub fn should_stop(&self) -> bool {
+        match self.stop_reason() {
+            Some(reason) => {
+                warn!(%reason, "daemon should stop");
+                true
+            }
+            None => false,
+        }
     }
 
     pub fn teardown(self) {
@@ -76,11 +166,89 @@ impl Daemon {
         }
     }
 
-    pub fn block(self) {
-        while !self.should_stop() {
+    pub fn block(self) -> StopReason {
+        let reason = loop {
+            if let Some(reason) = self.stop_reason() {
+                break reason;
+            }
+
             std::thread::sleep(Duration::from_millis(1500));
-        }
+        };
+
+        warn!(%reason, "stopping daemon");
 
         self.teardown();
+
+        reason
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::runtime::{spawn_stage, tests::MockStage, Policy};
+
+    fn wait_stop_reason(daemon: &Daemon) -> StopReason {
+        for _ in 0..300 {
+            if let Some(reason) = daemon.stop_reason() {
+                return reason;
+            }
+
+            std::thread::sleep(Duration::from_millis(10));
+        }
+
+        panic!("daemon never reached a stop condition");
+    }
+
+    fn long_running_stage() -> MockStage {
+        MockStage {
+            schedule_delay: Some(Duration::from_secs(60)),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn stop_reason_reports_finalized_when_a_worker_completes() {
+        let finalizer = MockStage {
+            done_after: Some(3),
+            ..Default::default()
+        };
+
+        let daemon = Daemon::new(vec![
+            spawn_stage(long_running_stage(), Policy::default()),
+            spawn_stage(finalizer, Policy::default()),
+        ]);
+
+        let reason = wait_stop_reason(&daemon);
+        assert_eq!(reason, StopReason::Finalized);
+        assert!(reason.is_graceful());
+
+        daemon.teardown();
+    }
+
+    #[test]
+    fn stop_reason_reports_crashed_when_a_worker_errors() {
+        let failing = MockStage {
+            failures: vec![true],
+            ..Default::default()
+        };
+
+        let daemon = Daemon::new(vec![
+            spawn_stage(long_running_stage(), Policy::default()),
+            spawn_stage(failing, Policy::default()),
+        ]);
+
+        let reason = wait_stop_reason(&daemon);
+
+        assert_eq!(
+            reason,
+            StopReason::Crashed {
+                stage: "mockstage".into()
+            }
+        );
+
+        assert!(!reason.is_graceful());
+
+        daemon.teardown();
     }
 }

--- a/gasket/src/daemon.rs
+++ b/gasket/src/daemon.rs
@@ -39,6 +39,30 @@ impl StopReason {
             StopReason::Terminated | StopReason::Finalized | StopReason::Dismissed { .. }
         )
     }
+
+    /// Which reason best explains the stop when several stages report one at
+    /// the same instant. A graceful finalization outranks a crash (a finished
+    /// producer routinely makes its consumers error as a cascade), a crash
+    /// outranks a stall, and a stall outranks an external dismissal.
+    fn precedence(&self) -> u8 {
+        match self {
+            StopReason::Terminated => 5,
+            StopReason::Finalized => 4,
+            StopReason::Crashed { .. } => 3,
+            StopReason::Blocked { .. } => 2,
+            StopReason::Dismissed { .. } => 1,
+        }
+    }
+
+    /// Keep whichever of two reasons better explains the stop, favouring the
+    /// earlier stage on a tie so the first offender is the one reported.
+    fn or_stronger(self, other: Self) -> Self {
+        if other.precedence() > self.precedence() {
+            other
+        } else {
+            self
+        }
+    }
 }
 
 impl fmt::Display for StopReason {
@@ -87,50 +111,47 @@ impl Daemon {
 
     /// Why the daemon should stop, if it should at all.
     ///
-    /// A worker that finished its work means graceful finalization, which
-    /// takes precedence over other stages erroring out as a cascading side
-    /// effect (eg: a port closing because its counterpart stage already
-    /// ended). The terminal `Ended` phase carries the `EndCause` it ended
-    /// with, so the classification reads straight off each tether's phase.
+    /// Each running stage either contributes a reason or none; the daemon
+    /// reports the one that best explains the stop (see
+    /// [`StopReason::precedence`]).
     pub fn stop_reason(&self) -> Option<StopReason> {
         if self.is_terminated() {
             return Some(StopReason::Terminated);
         }
 
-        let mut crashed = None;
-        let mut blocked = None;
-        let mut dismissed = None;
+        self.tethers()
+            .filter_map(Self::tether_stop_reason)
+            .reduce(StopReason::or_stronger)
+    }
 
-        for tether in self.tethers() {
-            let stage = || tether.name().to_owned();
+    /// How a single stage contributes to the stop decision, if at all. The
+    /// terminal `Ended` phase carries the `EndCause` it ended with, so the
+    /// reason reads straight off the tether's phase.
+    fn tether_stop_reason(tether: &Tether) -> Option<StopReason> {
+        let stage = || tether.name().to_owned();
 
-            match tether.check_state() {
-                // a stage that finalized gracefully wins outright
-                TetherState::Alive(StagePhase::Ended(EndCause::Done))
-                | TetherState::Finished(StagePhase::Ended(EndCause::Done)) => {
-                    return Some(StopReason::Finalized);
-                }
-                TetherState::Alive(StagePhase::Ended(EndCause::Errored))
-                | TetherState::Finished(StagePhase::Ended(EndCause::Errored)) => {
-                    crashed.get_or_insert_with(|| StopReason::Crashed { stage: stage() });
-                }
-                TetherState::Alive(StagePhase::Ended(EndCause::Dismissed))
-                | TetherState::Finished(StagePhase::Ended(EndCause::Dismissed)) => {
-                    dismissed.get_or_insert_with(|| StopReason::Dismissed { stage: stage() });
-                }
-                // the thread is gone but never reached `Ended`, so it panicked
-                // mid-work
-                TetherState::Dropped | TetherState::Finished(_) => {
-                    crashed.get_or_insert_with(|| StopReason::Crashed { stage: stage() });
-                }
-                TetherState::Blocked(_) => {
-                    blocked.get_or_insert_with(|| StopReason::Blocked { stage: stage() });
-                }
-                TetherState::Alive(_) => (),
+        match tether.check_state() {
+            // the stage reached its terminal phase; the cause it ended with
+            // names the reason
+            TetherState::Alive(StagePhase::Ended(cause))
+            | TetherState::Finished(StagePhase::Ended(cause)) => Some(match cause {
+                EndCause::Done => StopReason::Finalized,
+                EndCause::Errored => StopReason::Crashed { stage: stage() },
+                EndCause::Dismissed => StopReason::Dismissed { stage: stage() },
+            }),
+
+            // the thread is gone but never reached `Ended`, so it panicked
+            // mid-work
+            TetherState::Dropped | TetherState::Finished(_) => {
+                Some(StopReason::Crashed { stage: stage() })
             }
-        }
 
-        crashed.or(blocked).or(dismissed)
+            // the stage stopped ticking within its timeout
+            TetherState::Blocked(_) => Some(StopReason::Blocked { stage: stage() }),
+
+            // still working
+            TetherState::Alive(_) => None,
+        }
     }
 
     pub fn should_stop(&self) -> bool {

--- a/gasket/src/daemon.rs
+++ b/gasket/src/daemon.rs
@@ -63,6 +63,19 @@ impl StopReason {
             self
         }
     }
+
+    /// The reason a stage that reached its terminal phase stopped the daemon.
+    fn from_end_cause(cause: EndCause, stage: &str) -> Self {
+        match cause {
+            EndCause::Done => StopReason::Finalized,
+            EndCause::Errored => StopReason::Crashed {
+                stage: stage.to_owned(),
+            },
+            EndCause::Dismissed => StopReason::Dismissed {
+                stage: stage.to_owned(),
+            },
+        }
+    }
 }
 
 impl fmt::Display for StopReason {
@@ -124,33 +137,24 @@ impl Daemon {
             .reduce(StopReason::or_stronger)
     }
 
-    /// How a single stage contributes to the stop decision, if at all. The
-    /// terminal `Ended` phase carries the `EndCause` it ended with, so the
-    /// reason reads straight off the tether's phase.
+    /// How a single stage contributes to the stop decision, if at all.
     fn tether_stop_reason(tether: &Tether) -> Option<StopReason> {
-        let stage = || tether.name().to_owned();
+        let state = tether.check_state();
+        let stage = tether.name();
 
-        match tether.check_state() {
-            // the stage reached its terminal phase; the cause it ended with
-            // names the reason
-            TetherState::Alive(StagePhase::Ended(cause))
-            | TetherState::Finished(StagePhase::Ended(cause)) => Some(match cause {
-                EndCause::Done => StopReason::Finalized,
-                EndCause::Errored => StopReason::Crashed { stage: stage() },
-                EndCause::Dismissed => StopReason::Dismissed { stage: stage() },
-            }),
-
-            // the thread is gone but never reached `Ended`, so it panicked
-            // mid-work
-            TetherState::Dropped | TetherState::Finished(_) => {
-                Some(StopReason::Crashed { stage: stage() })
-            }
-
-            // the stage stopped ticking within its timeout
-            TetherState::Blocked(_) => Some(StopReason::Blocked { stage: stage() }),
-
+        if let Some(cause) = state.end_cause() {
+            Some(StopReason::from_end_cause(cause, stage))
+        } else if state.has_panicked() {
+            Some(StopReason::Crashed {
+                stage: stage.to_owned(),
+            })
+        } else if state.is_stalled() {
+            Some(StopReason::Blocked {
+                stage: stage.to_owned(),
+            })
+        } else {
             // still working
-            TetherState::Alive(_) => None,
+            None
         }
     }
 

--- a/gasket/src/runtime.rs
+++ b/gasket/src/runtime.rs
@@ -40,6 +40,16 @@ pub enum StagePhase {
     Ended(EndCause),
 }
 
+impl StagePhase {
+    /// The cause the stage ended with, if this is the terminal phase.
+    pub fn end_cause(&self) -> Option<EndCause> {
+        match self {
+            StagePhase::Ended(cause) => Some(*cause),
+            _ => None,
+        }
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum StageState<S>
 where
@@ -388,6 +398,33 @@ pub enum TetherState {
     Finished(StagePhase),
 }
 
+impl TetherState {
+    /// The cause the stage ended with, if it reached its terminal phase —
+    /// whether the thread is still winding down (`Alive`) or already gone
+    /// (`Finished`).
+    pub fn end_cause(&self) -> Option<EndCause> {
+        match self {
+            TetherState::Alive(phase) | TetherState::Finished(phase) => phase.end_cause(),
+            _ => None,
+        }
+    }
+
+    /// The stage thread is gone but never reached `Ended`, i.e. it panicked
+    /// mid-work.
+    pub fn has_panicked(&self) -> bool {
+        match self {
+            TetherState::Dropped => true,
+            TetherState::Finished(phase) => phase.end_cause().is_none(),
+            _ => false,
+        }
+    }
+
+    /// The stage stopped ticking within its timeout.
+    pub fn is_stalled(&self) -> bool {
+        matches!(self, TetherState::Blocked(_))
+    }
+}
+
 impl Tether {
     pub fn name(&self) -> &str {
         &self.name
@@ -414,10 +451,7 @@ impl Tether {
     /// Why the stage ended, if it has reached its terminal state. Derived from
     /// the last phase, so it remains readable after the stage thread is gone.
     pub fn end_cause(&self) -> Option<EndCause> {
-        match self.last_state.load() {
-            StagePhase::Ended(cause) => Some(cause),
-            _ => None,
-        }
+        self.last_state.load().end_cause()
     }
 
     pub fn check_state(&self) -> TetherState {

--- a/gasket/src/runtime.rs
+++ b/gasket/src/runtime.rs
@@ -16,19 +16,11 @@ use crate::{
 
 use crate::framework::*;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
-pub enum StagePhase {
-    Bootstrap,
-    Working,
-    Teardown,
-    Ended,
-}
-
-/// Why a stage reached (or is heading towards) its terminal state.
+/// Why a stage reached its terminal `Ended` state.
 ///
-/// All terminal paths in the state machine go through the `Ended` phase, so
-/// the phase alone can't tell a graceful completion from a worker error. The
-/// cause is recorded at the event that triggered the termination.
+/// Every terminal transition in the state machine carries one of these, so the
+/// phase that ends a stage records *why* it ended rather than collapsing every
+/// path into an indistinguishable `Ended`.
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum EndCause {
     /// the worker reported that all of its work is done
@@ -40,6 +32,14 @@ pub enum EndCause {
     Errored,
 }
 
+#[derive(Copy, Clone, Debug, PartialEq)]
+pub enum StagePhase {
+    Bootstrap,
+    Working,
+    Teardown,
+    Ended(EndCause),
+}
+
 #[derive(Clone, Debug)]
 pub enum StageState<S>
 where
@@ -48,8 +48,11 @@ where
     Bootstrap(Retry),
     Scheduling(S::Worker, Retry),
     Executing(S::Worker, S::Unit, Retry),
-    Teardown(S::Worker, Retry, Ended),
-    Ended,
+    /// The `Option<EndCause>` is the pending outcome: `Some(cause)` means the
+    /// stage will end with that cause once teardown completes, `None` means it
+    /// will restart (`WorkerError::Restart`).
+    Teardown(S::Worker, Retry, Option<EndCause>),
+    Ended(EndCause),
 }
 
 impl<S> StageState<S>
@@ -63,7 +66,7 @@ where
             StageState::Scheduling(x, ..) => Some(x),
             StageState::Executing(x, ..) => Some(x),
             StageState::Teardown(x, ..) => Some(x),
-            StageState::Ended => None,
+            StageState::Ended(_) => None,
         }
     }
 }
@@ -78,12 +81,10 @@ where
             StageState::Scheduling(..) => Self::Working,
             StageState::Executing(..) => Self::Working,
             StageState::Teardown(..) => Self::Teardown,
-            StageState::Ended => Self::Ended,
+            StageState::Ended(cause) => Self::Ended(*cause),
         }
     }
 }
-
-type Ended = bool;
 
 #[derive(Debug)]
 pub enum StageEvent<S>
@@ -100,8 +101,8 @@ where
     ExecuteError(S::Worker, S::Unit, WorkerError, Retry),
     BootstrapOk(S::Worker),
     BootstrapError(WorkerError, Retry),
-    TeardownOk(Ended),
-    TeardownError(S::Worker, WorkerError, Retry, Ended),
+    TeardownOk(Option<EndCause>),
+    TeardownError(S::Worker, WorkerError, Retry, Option<EndCause>),
 }
 
 struct StageMachine<S>
@@ -172,10 +173,8 @@ where
 
         tokio::select! {
             _ = self.anchor.dismissed.cancelled() => {
-                // there's no worker to flow through a `Dismissed` event yet,
-                // so the cause needs to be recorded here
-                self.note_end_cause(EndCause::Dismissed);
-                StageEvent::TeardownOk(true)
+                // there's no worker yet, so end straight away as dismissed
+                StageEvent::TeardownOk(Some(EndCause::Dismissed))
             }
             bootstrap = S::Worker::bootstrap(&self.stage) => {
                 match bootstrap {
@@ -238,7 +237,7 @@ where
         &mut self,
         mut worker: S::Worker,
         retry: Retry,
-        ended: Ended,
+        ended: Option<EndCause>,
     ) -> StageEvent<S> {
         retry
             .wait_backoff(&self.policy.teardown_retry, self.anchor.dismissed.clone())
@@ -256,15 +255,8 @@ where
             StageState::Scheduling(worker, retry) => self.schedule(worker, retry).await,
             StageState::Executing(worker, unit, retry) => self.execute(worker, unit, retry).await,
             StageState::Teardown(worker, retry, ended) => self.teardown(worker, retry, ended).await,
-            StageState::Ended => unreachable!("ended stage shouldn't actuate"),
+            StageState::Ended(_) => unreachable!("ended stage shouldn't actuate"),
         }
-    }
-
-    /// Records why the stage is terminating. The first cause wins; later
-    /// events (eg: a failing teardown after the worker reported done)
-    /// shouldn't reclassify the stage.
-    fn note_end_cause(&self, cause: EndCause) {
-        let _ = self.anchor.end_cause.compare_exchange(None, Some(cause));
     }
 
     fn apply(&self, event: StageEvent<S>) -> StageState<S> {
@@ -272,66 +264,52 @@ where
             StageEvent::BootstrapOk(w) => StageState::Scheduling(w, Retry::fresh()),
             StageEvent::BootstrapError(err, retry) => match err {
                 WorkerError::Retry if retry.maxed(&self.policy.bootstrap_retry) => {
-                    self.note_end_cause(EndCause::Errored);
-                    StageState::Ended
+                    StageState::Ended(EndCause::Errored)
                 }
                 WorkerError::Retry => StageState::Bootstrap(retry.next()),
-                _ => {
-                    self.note_end_cause(EndCause::Errored);
-                    StageState::Ended
-                }
+                _ => StageState::Ended(EndCause::Errored),
             },
             StageEvent::NextUnit(w, u) => StageState::Executing(w, u, Retry::fresh()),
             StageEvent::WorkerIdle(w) => StageState::Scheduling(w, Retry::fresh()),
             StageEvent::ScheduleError(w, err, retry) => match err {
-                WorkerError::Restart => StageState::Teardown(w, Retry::fresh(), false),
+                WorkerError::Restart => StageState::Teardown(w, Retry::fresh(), None),
                 WorkerError::Retry if !retry.maxed(&self.policy.work_retry) => {
                     StageState::Scheduling(w, retry.next())
                 }
                 WorkerError::Retry if retry.dismissed(&self.policy.work_retry) => {
                     StageState::Scheduling(w, Retry::fresh())
                 }
-                _ => {
-                    self.note_end_cause(EndCause::Errored);
-                    StageState::Teardown(w, Retry::fresh(), true)
-                }
+                _ => StageState::Teardown(w, Retry::fresh(), Some(EndCause::Errored)),
             },
             StageEvent::ExecuteOk(w) => StageState::Scheduling(w, Retry::fresh()),
             StageEvent::ExecuteError(w, u, err, retry) => match err {
-                WorkerError::Restart => StageState::Teardown(w, Retry::fresh(), false),
+                WorkerError::Restart => StageState::Teardown(w, Retry::fresh(), None),
                 WorkerError::Retry if !retry.maxed(&self.policy.work_retry) => {
                     StageState::Executing(w, u, retry.next())
                 }
                 WorkerError::Retry if retry.dismissed(&self.policy.work_retry) => {
                     StageState::Scheduling(w, Retry::fresh())
                 }
-                _ => {
-                    self.note_end_cause(EndCause::Errored);
-                    StageState::Teardown(w, Retry::fresh(), true)
-                }
+                _ => StageState::Teardown(w, Retry::fresh(), Some(EndCause::Errored)),
             },
             StageEvent::WorkerDone(w) => {
-                self.note_end_cause(EndCause::Done);
-                StageState::Teardown(w, Retry::fresh(), true)
+                StageState::Teardown(w, Retry::fresh(), Some(EndCause::Done))
             }
             StageEvent::MessagingError(w) => {
-                self.note_end_cause(EndCause::Errored);
-                StageState::Teardown(w, Retry::fresh(), true)
+                StageState::Teardown(w, Retry::fresh(), Some(EndCause::Errored))
             }
             StageEvent::Dismissed(w) => {
-                self.note_end_cause(EndCause::Dismissed);
-                StageState::Teardown(w, Retry::fresh(), true)
+                StageState::Teardown(w, Retry::fresh(), Some(EndCause::Dismissed))
             }
-            StageEvent::TeardownOk(false) => StageState::Bootstrap(Retry::fresh()),
-            StageEvent::TeardownOk(true) => StageState::Ended,
+            StageEvent::TeardownOk(None) => StageState::Bootstrap(Retry::fresh()),
+            StageEvent::TeardownOk(Some(cause)) => StageState::Ended(cause),
             StageEvent::TeardownError(w, err, retry, ended) => match err {
                 WorkerError::Retry if !retry.maxed(&self.policy.teardown_retry) => {
                     StageState::Teardown(w, retry.next(), ended)
                 }
-                _ => {
-                    self.note_end_cause(EndCause::Errored);
-                    StageState::Ended
-                }
+                // a teardown that gives up ends the stage; the original cause
+                // wins, falling back to `Errored` for a failed restart
+                _ => StageState::Ended(ended.unwrap_or(EndCause::Errored)),
             },
         }
     }
@@ -340,9 +318,9 @@ where
         let prev_state = self.state.take().unwrap();
         let prev_phase = StagePhase::from(&prev_state);
 
-        if prev_phase == StagePhase::Ended {
+        if matches!(prev_phase, StagePhase::Ended(_)) {
             self.state = Some(prev_state);
-            return StagePhase::Ended;
+            return prev_phase;
         }
 
         let event = self.actuate(prev_state).await;
@@ -369,7 +347,6 @@ pub struct Anchor {
     metrics: metrics::Registry,
     dismissed: tokio_util::sync::CancellationToken,
     last_state: Arc<AtomicCell<StagePhase>>,
-    end_cause: Arc<AtomicCell<Option<EndCause>>>,
     last_tick: AtomicCell<Instant>,
 }
 
@@ -380,7 +357,6 @@ impl Anchor {
             dismissed: tokio_util::sync::CancellationToken::new(),
             last_tick: AtomicCell::new(Instant::now()),
             last_state: Arc::new(AtomicCell::new(StagePhase::Bootstrap)),
-            end_cause: Arc::new(AtomicCell::new(None)),
         }
     }
 
@@ -396,9 +372,8 @@ impl Anchor {
 pub struct Tether {
     name: String,
     anchor_ref: Weak<Anchor>,
-    // strong handles that outlive the stage thread, unlike `anchor_ref`.
+    // strong handle that outlives the stage thread, unlike `anchor_ref`.
     last_state: Arc<AtomicCell<StagePhase>>,
-    end_cause: Arc<AtomicCell<Option<EndCause>>>,
     thread_handle: JoinHandle<()>,
     policy: Policy,
 }
@@ -436,10 +411,13 @@ impl Tether {
         anchor.dismiss_stage()
     }
 
-    /// Why the stage ended (or started ending), if a terminal cause was
-    /// reached. Remains readable after the stage thread is gone.
+    /// Why the stage ended, if it has reached its terminal state. Derived from
+    /// the last phase, so it remains readable after the stage thread is gone.
     pub fn end_cause(&self) -> Option<EndCause> {
-        self.end_cause.load()
+        match self.last_state.load() {
+            StagePhase::Ended(cause) => Some(cause),
+            _ => None,
+        }
     }
 
     pub fn check_state(&self) -> TetherState {
@@ -507,7 +485,7 @@ where
         .build()
         .unwrap();
 
-    rt.block_on(async { while machine.transition().await != StagePhase::Ended {} });
+    rt.block_on(async { while !matches!(machine.transition().await, StagePhase::Ended(_)) {} });
 }
 
 pub fn spawn_stage<S: Stage>(stage: S, policy: Policy) -> Tether
@@ -521,7 +499,6 @@ where
     let anchor = Arc::new(Anchor::new(metrics));
     let anchor_ref = Arc::downgrade(&anchor);
     let last_state = Arc::clone(&anchor.last_state);
-    let end_cause = Arc::clone(&anchor.end_cause);
 
     let policy2 = policy.clone();
     let name2 = name.clone();
@@ -534,7 +511,6 @@ where
         name,
         anchor_ref,
         last_state,
-        end_cause,
         thread_handle,
         policy,
     }
@@ -645,7 +621,7 @@ pub mod tests {
 
         machine.transition().await;
 
-        assert!(matches!(machine.state, Some(StageState::Ended)));
+        assert!(matches!(machine.state, Some(StageState::Ended(_))));
     }
 
     async fn should_bootstrap(machine: &mut StageMachine<MockStage>) {
@@ -813,6 +789,9 @@ pub mod tests {
         }
 
         // a graceful stop is retained as Finished(Ended), not collapsed to Dropped
-        assert_eq!(state, TetherState::Finished(StagePhase::Ended));
+        assert_eq!(
+            state,
+            TetherState::Finished(StagePhase::Ended(EndCause::Dismissed))
+        );
     }
 }

--- a/gasket/src/runtime.rs
+++ b/gasket/src/runtime.rs
@@ -24,6 +24,22 @@ pub enum StagePhase {
     Ended,
 }
 
+/// Why a stage reached (or is heading towards) its terminal state.
+///
+/// All terminal paths in the state machine go through the `Ended` phase, so
+/// the phase alone can't tell a graceful completion from a worker error. The
+/// cause is recorded at the event that triggered the termination.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum EndCause {
+    /// the worker reported that all of its work is done
+    Done,
+    /// the stage was dismissed from the outside
+    Dismissed,
+    /// a worker error (panic, exhausted retries or messaging failure)
+    /// terminated the stage
+    Errored,
+}
+
 #[derive(Clone, Debug)]
 pub enum StageState<S>
 where
@@ -156,6 +172,9 @@ where
 
         tokio::select! {
             _ = self.anchor.dismissed.cancelled() => {
+                // there's no worker to flow through a `Dismissed` event yet,
+                // so the cause needs to be recorded here
+                self.note_end_cause(EndCause::Dismissed);
                 StageEvent::TeardownOk(true)
             }
             bootstrap = S::Worker::bootstrap(&self.stage) => {
@@ -241,15 +260,26 @@ where
         }
     }
 
+    /// Records why the stage is terminating. The first cause wins; later
+    /// events (eg: a failing teardown after the worker reported done)
+    /// shouldn't reclassify the stage.
+    fn note_end_cause(&self, cause: EndCause) {
+        let _ = self.anchor.end_cause.compare_exchange(None, Some(cause));
+    }
+
     fn apply(&self, event: StageEvent<S>) -> StageState<S> {
         match event {
             StageEvent::BootstrapOk(w) => StageState::Scheduling(w, Retry::fresh()),
             StageEvent::BootstrapError(err, retry) => match err {
                 WorkerError::Retry if retry.maxed(&self.policy.bootstrap_retry) => {
+                    self.note_end_cause(EndCause::Errored);
                     StageState::Ended
                 }
                 WorkerError::Retry => StageState::Bootstrap(retry.next()),
-                _ => StageState::Ended,
+                _ => {
+                    self.note_end_cause(EndCause::Errored);
+                    StageState::Ended
+                }
             },
             StageEvent::NextUnit(w, u) => StageState::Executing(w, u, Retry::fresh()),
             StageEvent::WorkerIdle(w) => StageState::Scheduling(w, Retry::fresh()),
@@ -261,7 +291,10 @@ where
                 WorkerError::Retry if retry.dismissed(&self.policy.work_retry) => {
                     StageState::Scheduling(w, Retry::fresh())
                 }
-                _ => StageState::Teardown(w, Retry::fresh(), true),
+                _ => {
+                    self.note_end_cause(EndCause::Errored);
+                    StageState::Teardown(w, Retry::fresh(), true)
+                }
             },
             StageEvent::ExecuteOk(w) => StageState::Scheduling(w, Retry::fresh()),
             StageEvent::ExecuteError(w, u, err, retry) => match err {
@@ -272,18 +305,33 @@ where
                 WorkerError::Retry if retry.dismissed(&self.policy.work_retry) => {
                     StageState::Scheduling(w, Retry::fresh())
                 }
-                _ => StageState::Teardown(w, Retry::fresh(), true),
+                _ => {
+                    self.note_end_cause(EndCause::Errored);
+                    StageState::Teardown(w, Retry::fresh(), true)
+                }
             },
-            StageEvent::WorkerDone(w) => StageState::Teardown(w, Retry::fresh(), true),
-            StageEvent::MessagingError(w) => StageState::Teardown(w, Retry::fresh(), true),
-            StageEvent::Dismissed(w) => StageState::Teardown(w, Retry::fresh(), true),
+            StageEvent::WorkerDone(w) => {
+                self.note_end_cause(EndCause::Done);
+                StageState::Teardown(w, Retry::fresh(), true)
+            }
+            StageEvent::MessagingError(w) => {
+                self.note_end_cause(EndCause::Errored);
+                StageState::Teardown(w, Retry::fresh(), true)
+            }
+            StageEvent::Dismissed(w) => {
+                self.note_end_cause(EndCause::Dismissed);
+                StageState::Teardown(w, Retry::fresh(), true)
+            }
             StageEvent::TeardownOk(false) => StageState::Bootstrap(Retry::fresh()),
             StageEvent::TeardownOk(true) => StageState::Ended,
             StageEvent::TeardownError(w, err, retry, ended) => match err {
                 WorkerError::Retry if !retry.maxed(&self.policy.teardown_retry) => {
                     StageState::Teardown(w, retry.next(), ended)
                 }
-                _ => StageState::Ended,
+                _ => {
+                    self.note_end_cause(EndCause::Errored);
+                    StageState::Ended
+                }
             },
         }
     }
@@ -321,6 +369,7 @@ pub struct Anchor {
     metrics: metrics::Registry,
     dismissed: tokio_util::sync::CancellationToken,
     last_state: Arc<AtomicCell<StagePhase>>,
+    end_cause: Arc<AtomicCell<Option<EndCause>>>,
     last_tick: AtomicCell<Instant>,
 }
 
@@ -331,6 +380,7 @@ impl Anchor {
             dismissed: tokio_util::sync::CancellationToken::new(),
             last_tick: AtomicCell::new(Instant::now()),
             last_state: Arc::new(AtomicCell::new(StagePhase::Bootstrap)),
+            end_cause: Arc::new(AtomicCell::new(None)),
         }
     }
 
@@ -346,8 +396,9 @@ impl Anchor {
 pub struct Tether {
     name: String,
     anchor_ref: Weak<Anchor>,
-    // strong handle that outlives the stage thread, unlike `anchor_ref`.
+    // strong handles that outlive the stage thread, unlike `anchor_ref`.
     last_state: Arc<AtomicCell<StagePhase>>,
+    end_cause: Arc<AtomicCell<Option<EndCause>>>,
     thread_handle: JoinHandle<()>,
     policy: Policy,
 }
@@ -383,6 +434,12 @@ impl Tether {
     pub fn dismiss_stage(&self) -> Result<(), crate::error::Error> {
         let anchor = self.try_anchor()?;
         anchor.dismiss_stage()
+    }
+
+    /// Why the stage ended (or started ending), if a terminal cause was
+    /// reached. Remains readable after the stage thread is gone.
+    pub fn end_cause(&self) -> Option<EndCause> {
+        self.end_cause.load()
     }
 
     pub fn check_state(&self) -> TetherState {
@@ -464,6 +521,7 @@ where
     let anchor = Arc::new(Anchor::new(metrics));
     let anchor_ref = Arc::downgrade(&anchor);
     let last_state = Arc::clone(&anchor.last_state);
+    let end_cause = Arc::clone(&anchor.end_cause);
 
     let policy2 = policy.clone();
     let name2 = name.clone();
@@ -476,6 +534,7 @@ where
         name,
         anchor_ref,
         last_state,
+        end_cause,
         thread_handle,
         policy,
     }
@@ -489,9 +548,10 @@ pub mod tests {
 
     #[derive(Clone, Default)]
     pub struct MockStage {
-        failures: Vec<bool>,
-        schedule_delay: Option<Duration>,
-        execute_delay: Option<Duration>,
+        pub failures: Vec<bool>,
+        pub schedule_delay: Option<Duration>,
+        pub execute_delay: Option<Duration>,
+        pub done_after: Option<usize>,
     }
 
     impl Stage for MockStage {
@@ -544,6 +604,13 @@ pub mod tests {
 
             if let Some(delay) = stage.schedule_delay {
                 tokio::time::sleep(delay).await;
+            }
+
+            if stage
+                .done_after
+                .is_some_and(|max| self.schedule_count > max)
+            {
+                return Ok(WorkSchedule::Done);
             }
 
             Ok(WorkSchedule::Unit(self.schedule_count))


### PR DESCRIPTION
## Why

The daemon could tell *that* the pipeline stopped but not *why*. Every terminal path in the stage machine — worker done, dismissed, and errored (exhausted retries, messaging failure, panic) — funnels through the `Ended` phase. Only a hard thread panic dies mid-`Working`. So inspecting a tether's `TetherState`/`StagePhase` from the outside can't distinguish a stage that finalized its work gracefully from one that crashed: both look like `Ended` / `Finished(Ended)`.

A consumer (e.g. a daemon picking a process exit code) that derives "did it finalize?" from phase alone will read a crashed stage as a graceful finish.

## Change

Record the cause at the event that triggers termination, rather than reconstructing it from state afterward:

- New `EndCause` (`Done` / `Dismissed` / `Errored`), stamped in the state machine's `apply()` at the exact event — `WorkerDone` → `Done`, dismissals → `Dismissed`, worker/messaging/teardown errors → `Errored`. First cause wins (a failing teardown after `Done` doesn't reclassify the stage). Bootstrap-time dismissal is stamped directly since there's no worker to flow a `Dismissed` event through yet.
- Retained on the tether past the stage thread's death (alongside `last_state`) and exposed as `Tether::end_cause()`.
- New `Daemon::stop_reason() -> Option<StopReason>` classifying the stop as `Finalized` / `Terminated` / `Dismissed` / `Crashed` / `Blocked`, with `is_graceful()` and `Display`. A dead thread with no recorded cause means a hard panic → `Crashed`.
- `block()` now returns the `StopReason` so callers get a meaningful exit code without inspecting tether state. `should_stop()` is a thin wrapper over `stop_reason()` (unchanged behavior).

`block()`'s return type change (`()` → `StopReason`) is breaking; the version bump is left to the release tooling rather than edited by hand here.

## Tests

New `daemon` unit tests cover the distinction directly: a `WorkSchedule::Done` worker → `Finalized`, a failing worker → `Crashed { stage }`. `MockStage` gained a `done_after` knob to drive graceful completion.

(Pre-existing on `main`, unrelated: `stage_machine_happy_path` fails and clippy 1.95 flags two lints in `gasket-derive`.)

## Consumer

txpipe/oura#930 uses this to fix an exit-code bug where `or_panic()`-style stage failures were misread as graceful finalizations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)