### PR TITLE
Drop prometheus_exporter_base for a lightweight metrics endpoint

### DIFF
--- a/gasket-prometheus/Cargo.toml
+++ b/gasket-prometheus/Cargo.toml
@@ -12,4 +12,5 @@ authors = ["Santiago Carmuega <santiago@carmuega.me>"]
 
 [dependencies]
 gasket = { version = "0.11.0", path = "../gasket" }
-prometheus_exporter_base = { version = "1.4.0", features = ["hyper_server"] }
+tokio = { version = "1", features = ["net", "io-util", "rt"] }
+tracing = "0.1.37"

--- a/gasket-prometheus/src/lib.rs
+++ b/gasket-prometheus/src/lib.rs
@@ -1,77 +1,154 @@
 use gasket::daemon::Daemon;
-use prometheus_exporter_base::{
-    prelude::ServerOptions, render_prometheus, MetricType, PrometheusInstance, PrometheusMetric,
-};
-use std::{io::Write, net::SocketAddr, sync::Arc};
+use gasket::metrics::{Reading, Readings};
+use std::fmt::Write as _;
+use std::{net::SocketAddr, sync::Arc};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+use tracing::warn;
 
 fn sanitize_stage_name(raw: &str) -> String {
     raw.replace('-', "_")
 }
 
-fn write_counter(output: &mut impl Write, stage: &str, metric: &str, value: u64) {
+fn write_metric(output: &mut String, stage: &str, metric: &str, kind: &str, value: &str) {
     let name = format!("{}_{}", sanitize_stage_name(stage), metric);
-    let help = format!("{} counter for stage {}", metric, stage);
 
-    let mut pc = PrometheusMetric::build()
-        .with_name(&name)
-        .with_metric_type(MetricType::Counter)
-        .with_help(&help)
-        .build();
-
-    pc.render_and_append_instance(
-        &PrometheusInstance::new()
-            .with_value(value)
-            .with_current_timestamp()
-            .expect("error getting the current UNIX epoch"),
-    );
-
-    writeln!(output, "{}", pc.render()).unwrap();
+    let _ = writeln!(output, "# HELP {name} {metric} {kind} for stage {stage}");
+    let _ = writeln!(output, "# TYPE {name} {kind}");
+    let _ = writeln!(output, "{name} {value}");
 }
 
-fn write_gauge(output: &mut impl Write, stage: &str, metric: &str, value: i64) {
-    let name = format!("{}_{}", sanitize_stage_name(stage), metric);
-    let help = format!("{} gauge for stage {}", metric, stage);
+/// Serialize every stage's metrics into the Prometheus text exposition format.
+fn render_stages<'a>(stages: impl Iterator<Item = (&'a str, Readings)>) -> String {
+    let mut out = String::new();
 
-    let mut pc = PrometheusMetric::build()
-        .with_name(&name)
-        .with_metric_type(MetricType::Gauge)
-        .with_help(&help)
-        .build();
+    for (stage, readings) in stages {
+        for (key, reading) in readings {
+            match reading {
+                Reading::Count(x) => write_metric(&mut out, stage, key, "counter", &x.to_string()),
+                Reading::Gauge(x) => write_metric(&mut out, stage, key, "gauge", &x.to_string()),
+                _ => (),
+            }
+        }
+    }
 
-    pc.render_and_append_instance(
-        &PrometheusInstance::new()
-            .with_value(value)
-            .with_current_timestamp()
-            .expect("error getting the current UNIX epoch"),
+    out
+}
+
+/// Render the daemon's current metrics into the Prometheus text exposition
+/// format. Stages whose metrics can't be read (eg: already torn down) are
+/// skipped rather than failing the whole scrape.
+fn render(source: &Daemon) -> String {
+    render_stages(source.tethers().filter_map(|tether| {
+        match tether.read_metrics() {
+            Ok(readings) => Some((tether.name(), readings)),
+            Err(err) => {
+                warn!(stage = tether.name(), ?err, "couldn't read stage metrics");
+                None
+            }
+        }
+    }))
+}
+
+async fn handle_connection(mut socket: tokio::net::TcpStream, source: &Daemon) -> std::io::Result<()> {
+    // Drain (and ignore) the request. Metrics are served on any request, so we
+    // only need to consume enough to let the client finish sending.
+    let mut buf = [0u8; 1024];
+    let _ = socket.read(&mut buf).await?;
+
+    let body = render(source);
+
+    let response = format!(
+        "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/plain; version=0.0.4; charset=utf-8\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\
+         \r\n\
+         {}",
+        body.len(),
+        body,
     );
 
-    writeln!(output, "{}", pc.render()).unwrap();
+    socket.write_all(response.as_bytes()).await?;
+    socket.flush().await?;
+
+    Ok(())
 }
 
 pub async fn serve(addr: SocketAddr, source: Arc<Daemon>) {
-    let server_options = ServerOptions {
-        addr,
-        authorization: prometheus_exporter_base::prelude::Authorization::None,
-    };
+    let listener = TcpListener::bind(addr)
+        .await
+        .expect("can't bind prometheus metrics endpoint");
 
-    render_prometheus(server_options, source, |_, options| async move {
-        let mut out = vec![];
-
-        for tether in options.tethers() {
-            for (key, metric) in tether.read_metrics().unwrap() {
-                match metric {
-                    gasket::metrics::Reading::Count(x) => {
-                        write_counter(&mut out, tether.name(), key, x);
-                    }
-                    gasket::metrics::Reading::Gauge(x) => {
-                        write_gauge(&mut out, tether.name(), key, x);
-                    }
-                    _ => (),
-                }
+    loop {
+        let (socket, _) = match listener.accept().await {
+            Ok(conn) => conn,
+            Err(err) => {
+                warn!(?err, "error accepting metrics connection");
+                continue;
             }
-        }
+        };
 
-        Ok(String::from_utf8(out).unwrap())
-    })
-    .await;
+        let source = Arc::clone(&source);
+
+        tokio::spawn(async move {
+            if let Err(err) = handle_connection(socket, &source).await {
+                warn!(?err, "error serving metrics request");
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gasket::metrics::Reading;
+
+    #[test]
+    fn renders_counter_and_gauge_in_text_format() {
+        let stages = vec![(
+            "my-stage",
+            vec![
+                ("received_blocks", Reading::Count(42)),
+                ("chain_tip", Reading::Gauge(-7)),
+            ],
+        )];
+
+        let out = render_stages(stages.into_iter());
+
+        assert!(out.contains("# HELP my_stage_received_blocks received_blocks counter for stage my-stage"));
+        assert!(out.contains("# TYPE my_stage_received_blocks counter"));
+        assert!(out.contains("my_stage_received_blocks 42"));
+
+        assert!(out.contains("# TYPE my_stage_chain_tip gauge"));
+        assert!(out.contains("my_stage_chain_tip -7"));
+    }
+
+    #[test]
+    fn sanitizes_stage_name_but_keeps_help_label() {
+        let stages = vec![("a-b-c", vec![("ticks", Reading::Count(1))])];
+
+        let out = render_stages(stages.into_iter());
+
+        assert!(out.contains("# TYPE a_b_c_ticks counter"));
+        assert!(out.contains("a_b_c_ticks 1"));
+        // the human-readable help keeps the original stage name
+        assert!(out.contains("for stage a-b-c"));
+    }
+
+    #[test]
+    fn ignores_message_readings() {
+        let stages = vec![(
+            "s",
+            vec![
+                ("note", Reading::Message("hello".into())),
+                ("count", Reading::Count(3)),
+            ],
+        )];
+
+        let out = render_stages(stages.into_iter());
+
+        assert!(!out.contains("note"));
+        assert!(out.contains("s_count 3"));
+    }
 }


### PR DESCRIPTION
Closes #37.

## Problem

`gasket-prometheus` depended on `prometheus_exporter_base` v1.4.0 (`hyper_server`), which dragged an entire **legacy, parallel TLS + HTTP stack** into every consumer (e.g. oura) — second copies of crates downstreams already carry at current majors, so Cargo can't dedup them:

`rustls 0.20`, `hyper 0.14`/`http 0.2`, `hyper-rustls`/`tokio-rustls 0.23`, `ring 0.16`, `webpki`, `base64 0.13`, `env_logger 0.9` — pure overhead just to expose a plain-HTTP `/metrics` endpoint.

## Change

Replace it with a minimal `tokio::net::TcpListener` HTTP/1.1 server plus a hand-written Prometheus text-exposition serializer. `tokio` is already in the tree via `gasket`, so **no new heavy crates** are added — only two extra tokio features (`net`, `io-util`). No TLS is needed: scrape endpoints sit on plain HTTP behind the scraper.

The `gasket-prometheus` dependency subtree drops from **93 → 35 unique crates**.

The public surface — `gasket_prometheus::serve(addr, source)` — is unchanged, so downstreams just bump the pin (the oura-side bump is a deferred follow-up per #37).

## Compatibility

- Metric names, `# HELP`/`# TYPE` lines, and dash→underscore stage-name sanitization are byte-for-byte compatible.
- **One intentional behavior change:** per-sample timestamps are dropped. Prometheus discourages client-set timestamps (the scraper assigns scrape time, which equals "now" here), and this removed the last system-clock dependency.
- No auth (matches the previous `Authorization::None`).

## Verification

- `cargo build`/`clippy -p gasket-prometheus`: clean.
- 3 new unit tests on the pure text serializer: pass.
- End-to-end: a throwaway integration test hit the live socket and got `HTTP/1.1 200 OK` with `Content-Type: text/plain; version=0.0.4` — verified, then removed (hardcoded port would be CI-flaky; `serve` binds internally).
- `cargo tree` confirms the legacy crates are gone.

> Note: `gasket::runtime::tests::stage_machine_happy_path` fails on `--workspace`, but it fails identically on clean `main` — a pre-existing flaky test in an untouched crate, not a regression from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)